### PR TITLE
feat(ai): Enhance LLM prompt with workspace context

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -502,13 +502,30 @@ def get_todos_by_session(db: Session, session_id: int, requesting_user_id: int |
 
 def get_sessions_for_user(db: Session, user_id: int):
     """
-    Gets all sessions a user is a member of, along with their role in each.
+    Gets all sessions a user is a member of, returning their role in each.
+    This includes their private session (which has no name).
     """
     return db.query(
         models.Session.id,
         models.Session.name,
         models.SessionMember.role
     ).join(models.SessionMember).filter(models.SessionMember.user_id == user_id).all()
+
+def get_session_by_id_for_user(db: Session, session_id: int, user_id: int) -> models.Session | None:
+    """
+    Gets a session by its ID, but only if the user is a member of that session.
+    """
+    # First, check if the user is a member of the session.
+    member_check = db.query(models.SessionMember).filter(
+        models.SessionMember.session_id == session_id,
+        models.SessionMember.user_id == user_id
+    ).first()
+
+    if not member_check:
+        return None  # User is not a member
+
+    # If they are a member, return the session details.
+    return db.query(models.Session).filter(models.Session.id == session_id).first()
 
 def get_session_members(db: Session, session_id: int):
     """

--- a/app/main.py
+++ b/app/main.py
@@ -94,6 +94,12 @@ def chat_create_task(
     if not task_creation_graph:
         raise HTTPException(status_code=500, detail="Graph not initialized")
 
+    session_name = "Private" # Default to private
+    if request.current_session_id:
+        session = crud.get_session_by_id_for_user(db, session_id=request.current_session_id, user_id=current_user.id)
+        if session and session.name:
+            session_name = session.name
+
     # Initial state for the graph, ensuring all keys are present
     initial_state = {
         "user_query": request.user_query,
@@ -101,7 +107,7 @@ def chat_create_task(
         "description": None,
         "is_private": True,  # Default to private
         "is_global_public": False,
-        "session_name": None,
+        "session_name": session_name,
         "start_date": None,
         "end_date": None,
         "start_time": None,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -151,5 +151,6 @@ class VerificationRequestResponse(BaseModel):
 # --- Chat Schemas ---
 class ChatRequest(BaseModel):
     user_query: str
+    current_session_id: Optional[int] = None
     # In the future, you could add conversation history here
     # history: List[dict] = [] 

--- a/tests/integration/test_chat_api.py
+++ b/tests/integration/test_chat_api.py
@@ -100,4 +100,176 @@ def test_chat_create_task_in_personal_workspace(
     assert len(todos) == 1
     created_todo = todos[0]
     assert created_todo.title == "Update my personal resume"
-    assert created_todo.session_id == private_session.id 
+    assert created_todo.session_id == private_session.id
+
+@patch("app.llm_service.ChatOpenAI")
+@patch("langchain_core.runnables.base.RunnableSequence.invoke")
+def test_chat_create_task_implicit_team_workspace(
+    mock_chain_invoke: MagicMock,
+    mock_chat_openai: MagicMock,
+    client: TestClient, 
+    db: Session, 
+    test_user_token_headers: dict
+):
+    """
+    Tests creating a task in the *current* team workspace when no specific
+    workspace is mentioned in the query.
+    """
+    # 1. Setup
+    response = client.get("/users/me", headers=test_user_token_headers)
+    current_user = schemas.User(**response.json())
+    current_session = crud.create_team_session(db, session=schemas.SessionCreate(name="Design Team"), owner_id=current_user.id)
+
+    # 2. Mock the LLM to return a task title but NO session_name,
+    # because the user query is implicit.
+    mock_chain_invoke.return_value = TaskDetails(
+        task_title="Review new wireframes",
+        description="Check the latest designs for the new feature."
+    )
+    
+    # 3. Call the API, passing the current_session_id
+    response = client.post(
+        "/chat/create-task",
+        headers=test_user_token_headers,
+        json={
+            "user_query": "Review the new wireframes",
+            "current_session_id": current_session.id
+        }
+    )
+
+    # 4. Assertions
+    assert response.status_code == 200
+    
+    todos = crud.get_todos_by_session(db, session_id=current_session.id, requesting_user_id=current_user.id)
+    assert len(todos) == 1
+    created_todo = todos[0]
+    assert created_todo.title == "Review new wireframes"
+    assert created_todo.session_id == current_session.id 
+
+@patch("app.llm_service.ChatOpenAI")
+@patch("langchain_core.runnables.base.RunnableSequence.invoke")
+def test_chat_create_task_explicit_different_team_workspace(
+    mock_chain_invoke: MagicMock,
+    mock_chat_openai: MagicMock,
+    client: TestClient,
+    db: Session,
+    test_user_token_headers: dict
+):
+    """
+    Tests creating a task in a DIFFERENT team workspace from the one the
+    user is currently in, by explicitly mentioning it in the query.
+    """
+    # 1. Setup
+    response = client.get("/users/me", headers=test_user_token_headers)
+    current_user = schemas.User(**response.json())
+    current_session = crud.create_team_session(db, session=schemas.SessionCreate(name="General"), owner_id=current_user.id)
+    target_session = crud.create_team_session(db, session=schemas.SessionCreate(name="Marketing"), owner_id=current_user.id)
+
+    # 2. Mock the LLM to return the *target* session name
+    mock_chain_invoke.return_value = TaskDetails(
+        task_title="Draft Q3 social media plan",
+        session_name="Marketing"
+    )
+
+    # 3. Call the API, passing the *current* session_id
+    response = client.post(
+        "/chat/create-task",
+        headers=test_user_token_headers,
+        json={
+            "user_query": "For the Marketing workspace, draft the Q3 social media plan",
+            "current_session_id": current_session.id
+        }
+    )
+
+    # 4. Assertions
+    assert response.status_code == 200
+
+    # The task should be in the 'Marketing' session, not 'General'
+    target_todos = crud.get_todos_by_session(db, session_id=target_session.id, requesting_user_id=current_user.id)
+    assert len(target_todos) == 1
+    assert target_todos[0].title == "Draft Q3 social media plan"
+
+    current_todos = crud.get_todos_by_session(db, session_id=current_session.id, requesting_user_id=current_user.id)
+    assert len(current_todos) == 0
+
+@patch("app.llm_service.ChatOpenAI")
+@patch("langchain_core.runnables.base.RunnableSequence.invoke")
+def test_chat_create_task_global_public(
+    mock_chain_invoke: MagicMock,
+    mock_chat_openai: MagicMock,
+    client: TestClient,
+    db: Session,
+    test_user_token_headers: dict
+):
+    """
+    Tests creating a task that is marked as globally public.
+    """
+    # 1. Setup
+    response = client.get("/users/me", headers=test_user_token_headers)
+    current_user = schemas.User(**response.json())
+
+    # 2. Mock the LLM to return `is_global_public=True`
+    mock_chain_invoke.return_value = TaskDetails(
+        task_title="Announce company-wide holiday",
+        is_global_public=True
+    )
+
+    # 3. Call the API
+    response = client.post(
+        "/chat/create-task",
+        headers=test_user_token_headers,
+        json={"user_query": "Announce the company-wide holiday to everyone"}
+    )
+
+    # 4. Assertions
+    assert response.status_code == 200
+
+    # The task should be marked as globally public
+    # It will be in the user's private session by default
+    todos = crud.get_todos_by_user(db, user_id=current_user.id)
+    assert len(todos) == 1
+    created_todo = todos[0]
+    assert created_todo.title == "Announce company-wide holiday"
+    assert created_todo.is_global_public is True
+    assert created_todo.is_private is False # Global tasks cannot be private 
+
+@patch("app.llm_service.ChatOpenAI")
+@patch("langchain_core.runnables.base.RunnableSequence.invoke")
+def test_chat_create_task_clarification_loop(
+    mock_chain_invoke: MagicMock,
+    mock_chat_openai: MagicMock,
+    client: TestClient,
+    db: Session,
+    test_user_token_headers: dict
+):
+    """
+    Tests that the API returns a clarification question if the task title
+    cannot be determined from the user's query.
+    """
+    # 1. Setup
+    response = client.get("/users/me", headers=test_user_token_headers)
+    current_user = schemas.User(**response.json())
+
+    # 2. Mock the LLM to return an incomplete result (no title)
+    mock_chain_invoke.return_value = TaskDetails(
+        description="A meeting about the project"
+    )
+
+    # 3. Call the API
+    response = client.post(
+        "/chat/create-task",
+        headers=test_user_token_headers,
+        json={"user_query": "schedule a meeting about the project"}
+    )
+
+    # 4. Assertions
+    assert response.status_code == 200
+    response_data = response.json()
+    
+    # Check for the clarification question in the response
+    assert response_data["is_complete"] is False
+    assert "I'm sorry, I couldn't determine a task title. What is the task?" in response_data["clarification_questions"]
+
+    # Verify that no task was created
+    todos = crud.get_todos_by_user(db, user_id=current_user.id)
+    assert len(todos) == 0 


### PR DESCRIPTION
- Updated the /chat/create-task endpoint to accept current_session_id.
- Modified the LLM prompt to be aware of the user's current workspace (session), allowing it to correctly infer task placement.
- Added a new CRUD function to securely fetch a session by ID for a specific user.
- Implemented comprehensive unit and integration tests to cover various scenarios, including implicit/explicit workspace assignment, global tasks, and the clarification loop.